### PR TITLE
Removed nl2br()

### DIFF
--- a/conv.php
+++ b/conv.php
@@ -261,7 +261,7 @@ src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
         $o = $dir == 1 ? tolv($c) : fromlv($c);
         ?>
         <h2>Rezultāts</h2>
-        <textarea style="margin-left: 3em; " class="t"><?=nl2br(htmlspecialchars($o));?></textarea>
+        <textarea style="margin-left: 3em; " class="t"><?=htmlspecialchars($o);?></textarea>
     <?}?>
     
     <h2>Transliterācijas tabula</h2>


### PR DESCRIPTION
The script was unusable if you have multi-paragraph text. This removes the annoying <br/> tags.